### PR TITLE
update(infra): manage Amplify app via Console, Terraform handles CORS…

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,6 +5,8 @@ applications:
       phases:
         preBuild:
           commands:
+            - nvm install 22
+            - nvm use 22
             - npm ci
         build:
           commands:

--- a/infra/amplify.tf
+++ b/infra/amplify.tf
@@ -1,25 +1,8 @@
+# Amplify app is created manually via AWS Console (with GitHub connection).
+# Terraform only uses the Amplify domain for CORS / Cognito callback configuration.
+
 locals {
-  amplify_branch_name = "main"
-  amplify_domain      = "${aws_amplify_app.frontend.default_domain}"
-  amplify_branch_url  = "https://${local.amplify_branch_name}.${local.amplify_domain}"
-}
-
-resource "aws_amplify_app" "frontend" {
-  name     = "${local.name}-frontend"
-  platform = "WEB"
-
-  build_spec = file("${path.module}/../amplify.yml")
-}
-
-resource "aws_amplify_branch" "main" {
-  app_id      = aws_amplify_app.frontend.id
-  branch_name = local.amplify_branch_name
-
-  environment_variables = {
-    NEXT_PUBLIC_COGNITO_DOMAIN       = "${aws_cognito_user_pool_domain.this.domain}.auth.${var.region}.amazoncognito.com"
-    NEXT_PUBLIC_COGNITO_CLIENT_ID    = aws_cognito_user_pool_client.web.id
-    NEXT_PUBLIC_API_BASE_URL         = aws_apigatewayv2_api.http.api_endpoint
-    NEXT_PUBLIC_COGNITO_REDIRECT_URI = "${local.amplify_branch_url}/"
-    NEXT_PUBLIC_COGNITO_LOGOUT_URI   = "${local.amplify_branch_url}/"
-  }
+  amplify_branch_url = var.amplify_domain != "" ? "https://main.${var.amplify_domain}" : ""
+  amplify_origins    = local.amplify_branch_url != "" ? [local.amplify_branch_url] : []
+  amplify_urls       = local.amplify_branch_url != "" ? ["${local.amplify_branch_url}/"] : []
 }

--- a/infra/api.tf
+++ b/infra/api.tf
@@ -6,7 +6,7 @@ locals {
   cors_origins = distinct(concat(
     [for o in var.callback_urls : trimsuffix(o, "/")],
     ["http://localhost:3000"],
-    [local.amplify_branch_url],
+    local.amplify_origins,
   ))
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -33,8 +33,8 @@ resource "aws_cognito_user_pool_client" "web" {
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["email", "openid", "profile"]
 
-  callback_urls = distinct(concat(var.callback_urls, ["${local.amplify_branch_url}/"]))
-  logout_urls   = distinct(concat(var.logout_urls, ["${local.amplify_branch_url}/"]))
+  callback_urls = distinct(concat(var.callback_urls, local.amplify_urls))
+  logout_urls   = distinct(concat(var.logout_urls, local.amplify_urls))
 
   supported_identity_providers = ["COGNITO"]
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -42,8 +42,12 @@ output "s3_question_sets_bucket" {
   value = aws_s3_bucket.question_sets.bucket
 }
 
-output "amplify_app_url" {
-  value       = "${local.amplify_branch_url}/"
-  description = "Amplify Hosting frontend URL"
+output "amplify_env_vars" {
+  description = "Environment variables to set in Amplify Console"
+  value = {
+    NEXT_PUBLIC_COGNITO_DOMAIN    = "${aws_cognito_user_pool_domain.this.domain}.auth.${var.region}.amazoncognito.com"
+    NEXT_PUBLIC_COGNITO_CLIENT_ID = aws_cognito_user_pool_client.web.id
+    NEXT_PUBLIC_API_BASE_URL      = aws_apigatewayv2_api.http.api_endpoint
+  }
 }
 

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -28,7 +28,7 @@ resource "aws_s3_bucket_cors_configuration" "question_sets" {
     allowed_methods = ["GET", "PUT"]
     allowed_origins = distinct(concat(
       [for o in var.callback_urls : trimsuffix(o, "/")],
-      [local.amplify_branch_url],
+      local.amplify_origins,
     ))
     allowed_headers = ["*"]
     expose_headers  = ["ETag"]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -16,6 +16,12 @@ variable "cognito_domain_prefix" {
   default     = "exam-sim"
 }
 
+variable "amplify_domain" {
+  type        = string
+  description = "Amplify app default domain (e.g. d1abc2def3.amplifyapp.com). Set after creating the app in Amplify Console."
+  default     = ""
+}
+
 variable "callback_urls" {
   type        = list(string)
   description = "Allowed OAuth callback URLs for Cognito hosted UI."


### PR DESCRIPTION
… only

Amplify app with GitHub connection is created in AWS Console. Terraform manages CORS/callback URLs using amplify_domain variable. Also pin Node.js 22 in amplify.yml for Next.js 16 compatibility.